### PR TITLE
feat(provisioner): Automate VM and Docker image acquisition

### DIFF
--- a/internal/cloudinit/cloudinit_test.go
+++ b/internal/cloudinit/cloudinit_test.go
@@ -61,7 +61,7 @@ func TestCreateISO(t *testing.T) {
 	// Test case for "provisioner" role
 	t.Run("provisioner", func(t *testing.T) {
 		isoPath := filepath.Join(appDir, "provisioner.iso")
-		err := CreateISO("test-vm", "provisioner", appDir, isoPath, "192.168.1.1/24", "", "", "pxe-stack.tar")
+		err := CreateISO("test-vm", "provisioner", appDir, isoPath, "192.168.1.1/24", "", "", "pxe-stack.tar", "ghcr.io/user/repo:tag")
 		if err != nil {
 			t.Fatalf("CreateISO() for provisioner returned an error: %v", err)
 		}
@@ -75,7 +75,7 @@ func TestCreateISO(t *testing.T) {
 	// Test case for "target" role
 	t.Run("target", func(t *testing.T) {
 		isoPath := filepath.Join(appDir, "target.iso")
-		err := CreateISO("test-vm-target", "target", appDir, isoPath, "", "", "52:54:00:12:34:56", "")
+		err := CreateISO("test-vm-target", "target", appDir, isoPath, "", "", "52:54:00:12:34:56", "", "")
 		if err != nil {
 			t.Fatalf("CreateISO() for target returned an error: %v", err)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -19,6 +20,40 @@ const (
 	// UbuntuAMD64ImageURL is the full URL for the Ubuntu x86_64 cloud image
 	UbuntuAMD64ImageURL = UbuntuCloudImageBaseURL + UbuntuAMD64ImageName
 )
+
+// Version is the version of the application. It is set at build time.
+var Version = "devel"
+
+// GetProvisionerImageURL returns the URL for the provisioner image based on the
+// application version and architecture.
+func GetProvisionerImageURL(arch string) (string, string) {
+
+	var imageName string
+	if arch == "aarch64" {
+		imageName = "provisioner-custom.arm64.qcow2"
+	} else {
+		imageName = "provisioner-custom.amd64.qcow2"
+	}
+
+	var url string
+	if Version == "devel" {
+		url = fmt.Sprintf("https://github.com/pallotron/pvmlab/releases/latest/download/%s", imageName)
+	} else {
+		url = fmt.Sprintf("https://github.com/pallotron/pvmlab/releases/download/%s/%s", Version, imageName)
+	}
+
+	return url, imageName
+}
+
+// GetPxeBootStackImageURL returns the URL for the pxeboot stack image based on
+// the application version.
+func GetPxeBootStackImageURL() string {
+	version := Version
+	if Version == "devel" {
+		version = "latest"
+	}
+	return fmt.Sprintf("ghcr.io/pallotron/pvmlab/pxeboot_stack:%s", version)
+}
 
 // Config holds the application's configuration.
 type Config struct {

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -13,7 +14,7 @@ import (
 )
 
 // DownloadFile downloads a file from a URL to a local path.
-func DownloadFile(filepath string, url string) error {
+func DownloadFile(path string, url string) error {
 	resp, err := http.Get(url)
 	if err != nil {
 		return err
@@ -24,7 +25,13 @@ func DownloadFile(filepath string, url string) error {
 		return fmt.Errorf("failed to download file from %s: %s", url, resp.Status)
 	}
 
-	out, err := os.Create(filepath)
+	// Ensure the destination directory exists.
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", dir, err)
+	}
+
+	out, err := os.Create(path)
 	if err != nil {
 		return err
 	}

--- a/pvmlab/cmd/main_test.go
+++ b/pvmlab/cmd/main_test.go
@@ -77,10 +77,10 @@ func setupMocks(_ *testing.T) {
 	createDisk = func(string, string, string) error {
 		return nil
 	}
-	createISO = func(string, string, string, string, string, string, string, string) error {
+	createISO = func(string, string, string, string, string, string, string, string, string) error {
 		return nil
 	}
-	cloudinit.CreateISO = func(string, string, string, string, string, string, string, string) error {
+	cloudinit.CreateISO = func(string, string, string, string, string, string, string, string, string) error {
 		return nil
 	}
 	metadata.Save = func(*config.Config, string, string, string, string, string, string, string, string, string, string, string, int, bool) error {

--- a/pvmlab/cmd/vm_create_test.go
+++ b/pvmlab/cmd/vm_create_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"pvmlab/internal/cloudinit"
 	"pvmlab/internal/config"
 	"pvmlab/internal/metadata"
 	"strings"
@@ -68,7 +69,7 @@ func TestVMCreateCommand(t *testing.T) {
 			name: "iso create failure",
 			args: []string{"vm", "create", "test-vm", "--role", "target"},
 			setupMocks: func() {
-				createISO = func(string, string, string, string, string, string, string, string) error {
+				cloudinit.CreateISO = func(string, string, string, string, string, string, string, string, string) error {
 					return errors.New("iso creation failed")
 				}
 			},

--- a/pvmlab/cmd/vm_start.go
+++ b/pvmlab/cmd/vm_start.go
@@ -51,9 +51,10 @@ var vmStartCmd = &cobra.Command{
 		}
 
 		isPxeBoot := opts.meta.PxeBoot
-		if bootOverride == "pxe" {
+		switch bootOverride {
+		case "pxe":
 			isPxeBoot = true
-		} else if bootOverride == "disk" {
+		case "disk":
 			isPxeBoot = false
 		}
 
@@ -146,9 +147,10 @@ func buildQEMUArgs(opts *vmStartOptions) ([]string, error) {
 
 	// Determine the effective boot mode
 	isPxeBoot := opts.meta.PxeBoot
-	if bootOverride == "pxe" {
+	switch bootOverride {
+	case "pxe":
 		isPxeBoot = true
-	} else if bootOverride == "disk" {
+	case "disk":
 		isPxeBoot = false
 	}
 
@@ -235,6 +237,7 @@ func buildQEMUArgs(opts *vmStartOptions) ([]string, error) {
 			"-netdev", fmt.Sprintf("user,id=net0,hostfwd=tcp::%d-:22,ipv6=on,ipv4=on,ipv6-net=fd00::/64", opts.meta.SSHPort),
 			"-device", fmt.Sprintf("%s,netdev=net1,mac=%s", netDevice, opts.meta.MAC),
 			"-netdev", "socket,id=net1,fd=3",
+
 			"-virtfs", fmt.Sprintf("local,path=%s,mount_tag=host_share_docker_images,security_model=passthrough", finalDockerImagesPath),
 			"-virtfs", fmt.Sprintf("local,path=%s,mount_tag=host_share_vms,security_model=passthrough", finalVMsPath),
 		)


### PR DESCRIPTION
This commit enhances the provisioner creation process by automatically downloading the required VM disk image and pulling the PXE boot stack Docker image. This removes the need for users to manually acquire these assets, simplifying the setup.

Key changes:

 1. Provisioner VM Image Download: - Instead of relying on a generic, local Ubuntu cloud image, the tool now downloads a specialized provisioner-custom.qcow2 image directly from the project's GitHub Releases. To speed up integration tests. - The image URL is dynamically constructed based on the application version (Version) and the target architecture.

 2. PXE Boot Stack Docker Image Pull:
     - If a local tarball is not provided via the --docker-pxeboot-stack-tar flag, the tool will now automatically pull the pxeboot_stack Docker image from a container registry (e.g., GHCR).
     - The pulled image is then saved to a .tar file within the ~/.pvmlab/docker_images directory for use by the provisioner VM.

These changes streamline the user experience and ensure that the correct, version-aligned images are always used for the provisioner.